### PR TITLE
updating responsive layouts

### DIFF
--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -15,6 +15,19 @@
 @media (min-width: 500px) {
   .app {
     grid-template-areas:
+      ". header header ."
+      ". artboard artboard ."
+      ". primary-tools secondary-tools ."
+      ". footer footer .";
+    grid-template-columns: 1fr repeat(2, 240px) 1fr;
+    grid-template-rows: auto 1fr auto auto;
+    grid-gap: 8px;
+  }
+}
+
+@media (min-width: 900px) {
+  .app {
+    grid-template-areas:
       "primary-tools header secondary-tools"
       "primary-tools artboard secondary-tools"
       "primary-tools footer secondary-tools";

--- a/src/components/Copy.js
+++ b/src/components/Copy.js
@@ -13,7 +13,7 @@ const Copy = () => {
     copy(output)
   }
   return (
-    <button className="button" onClick={copyText}>Copy to clipboard</button>
+    <button type="button" className="button" onClick={copyText}>Copy to clipboard</button>
   )
 }
 

--- a/src/components/Download.js
+++ b/src/components/Download.js
@@ -15,7 +15,7 @@ const handleDownload = () => {
 
 const Download = () => {
   return (
-    <button className="button" onClick={handleDownload}>Download PNG</button>
+    <button type="button" className="button" onClick={handleDownload}>Download PNG</button>
   )
 }
 

--- a/src/components/EmojiPicker.js
+++ b/src/components/EmojiPicker.js
@@ -5,7 +5,7 @@ import Picker from "@emoji-mart/react";
 import data from "@emoji-mart/data";
 import css from "./EmojiPicker.module.css";
 
-const EmojiPicker = ({ updateTool, edit }) => {
+const EmojiPicker = ({ handleEmojiSelect, handleClickOutside, edit }) => {
   return (
     <div
       className={cx(css.container, {
@@ -15,21 +15,21 @@ const EmojiPicker = ({ updateTool, edit }) => {
       <Picker
         data={data}
         set="native"
+        // @todo find out what this prop is now
         title="Pick your paint…"
         previewEmoji="point_up_2"
-        onEmojiSelect={(emoji) => updateTool({ paint: emoji.native })}
+        onEmojiSelect={(emoji) => handleEmojiSelect?.({ paint: emoji.native })}
+        onClickOutside={handleClickOutside}
         emojiButtonColors={['var(--color2)']}
         theme="light"
-        style={{
-          "--border-radius": 0,
-        }}
       />
     </div>
   );
 };
 
 EmojiPicker.propTypes = {
-  updateTool: PropTypes.func.isRequired,
+  handleEmojiSelect: PropTypes.func,
+  handleClickOutside: PropTypes.func,
   edit: PropTypes.bool,
 };
 

--- a/src/components/EmojiPicker.module.css
+++ b/src/components/EmojiPicker.module.css
@@ -1,3 +1,4 @@
+/* @todo: move these container rules to the consuming components */
 .container {
   position: fixed;
   top: 50px;
@@ -5,6 +6,24 @@
   z-index: 99;
   transform: translateX(-50%);
   z-index: 101; /* this has to be above topLayer */
+}
+
+@media (min-width: 500px) {
+  .container {
+    position: absolute;
+    top: 0;
+    right: auto;
+    left: calc(100% + 12px);
+    transform: translateY(-50%);
+    z-index: 10;
+  }
+}
+
+@media (min-width: 500px) {
+  .container.edit {
+    right: calc(100% + 12px);
+    left: auto;
+  }
 }
 
 em-emoji-picker {
@@ -22,7 +41,7 @@ em-emoji-picker {
   --rgb-input: 255, 235, 235;
 
   --border-radius: 0;
-  --shadow: 6px 6px 0 0 var(--color1), 6px 6px 100px 25px var(--color3);
+  --shadow: 6px 6px 0 0 var(--color1), 6px 6px 100px 25px var(--highlight);
 }
 
 @media (max-width: 499px) {
@@ -30,16 +49,5 @@ em-emoji-picker {
     position: absolute;
     top: auto;
     bottom: 235px;
-  }
-}
-
-@media (min-width: 500px) {
-  .container {
-    position: absolute;
-    top: 0;
-    right: calc(100% + 12px);
-    left: auto;
-    transform: translateY(-50%);
-    z-index: 10;
   }
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react'
-import useStore from "../store/store";
 import cx from 'classnames'
 import useKey from 'react-use/lib/useKey'
 import Help from './Help'
@@ -7,10 +6,9 @@ import logo from '../images/logo.svg'
 import css from './Header.module.css'
 
 const Header = () => {
-  const shortcutsEnabled = useStore((state) => state.allowShortcuts)
   const [isHelping, setHelping] = useState(false)
   useKey('Escape', () => setHelping(false))
-  useKey('h', () => shortcutsEnabled && setHelping(true), {}, [shortcutsEnabled])
+  useKey('h', () => setHelping(true), {}, [])
 
   const helpNode = useRef()
   const helpButton = useRef()

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -43,6 +43,7 @@ const Header = () => {
         EmojiBrush
       </h1>
       <button
+        type="button"
         ref={helpButton}
         className={cx(css.help, {
           [css.helping]: isHelping,

--- a/src/components/History.js
+++ b/src/components/History.js
@@ -7,7 +7,7 @@ const Clear = () => {
 
   return (
     <div className={css.tool}>
-      <button onClick={handleClear} className={css.button}>
+      <button type="button" onClick={handleClear} className={css.button}>
         <span className={css.buttonLayout}>
           <span className={css.icon} role="img" aria-label="Clear">
             🧨

--- a/src/components/Paint.js
+++ b/src/components/Paint.js
@@ -39,14 +39,16 @@ const Paint = ({ tool, updateTool }) => {
 
   return (
     <Fragment>
-      <div className={css.paint} ref={paintButtons}>
-        <div className={cx(css.swatch, css.active)}>{tool.paint}</div>
-        <div
-          className={cx(css.swatch, css.alternate)}
-          onClick={() => handleSwap()}
-          role="button"
-        >
-          {tool.alternatePaint}
+      <div>
+        <div className={css.paint} ref={paintButtons}>
+          <div className={cx(css.swatch, css.active)}>{tool.paint}</div>
+          <div
+            className={cx(css.swatch, css.alternate)}
+            onClick={() => handleSwap()}
+            role="button"
+          >
+            {tool.alternatePaint}
+          </div>
         </div>
       </div>
       <button

--- a/src/components/Paint.js
+++ b/src/components/Paint.js
@@ -1,10 +1,19 @@
-import React from 'react'
+import React, { Fragment, useRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import useKey from 'react-use/lib/useKey'
+import useStore from "../store/store";
+import EmojiPicker from './EmojiPicker'
 import css from './Paint.module.css'
 
 const Paint = ({ tool, updateTool }) => {
+  const pickerNode = useRef()
+  const pickerButtonNode = useRef()
+  const paintButtons = useRef()
+  
+  const showPicker = useStore((state) => state.showPicker)
+  const setShowPicker = useStore((state) => state.setShowPicker)
+
   const handleSwap = () => {
     updateTool({
       paint: tool.alternatePaint,
@@ -12,10 +21,25 @@ const Paint = ({ tool, updateTool }) => {
     })
   }
 
+  const handleClickOutside = useCallback((e) => {
+    if (paintButtons.current.contains(e.target)) return
+    if (pickerButtonNode.current.contains(e.target)) return
+
+    setShowPicker(false)
+  }, [setShowPicker])
+
+  
+  useKey('s', () => setShowPicker(true), {}, [])
   useKey('x', handleSwap, {}, [tool])
+  useKey('Escape', () => {
+    if (showPicker) {
+      setShowPicker(false)
+    }
+  }, {}, [showPicker])
+
   return (
-    <div>
-      <div className={css.paint}>
+    <Fragment>
+      <div className={css.paint} ref={paintButtons}>
         <div className={cx(css.swatch, css.active)}>{tool.paint}</div>
         <div
           className={cx(css.swatch, css.alternate)}
@@ -25,7 +49,23 @@ const Paint = ({ tool, updateTool }) => {
           {tool.alternatePaint}
         </div>
       </div>
-    </div>
+      <button
+        type="button"
+        ref={pickerButtonNode}
+        className={cx("button", {
+          [css.showPicker]: showPicker,
+          'topLayer': showPicker
+        })}
+        onClick={() => setShowPicker(!showPicker)}
+      >
+        {showPicker ? 'Hide' : 'Show'} EmojiPicker
+      </button>
+      <div ref={pickerNode} className={css.picker}>
+        {showPicker &&
+          <EmojiPicker handleEmojiSelect={updateTool} handleClickOutside={handleClickOutside} />
+        }
+      </div>
+    </Fragment>
   )
 }
 

--- a/src/components/Paint.module.css
+++ b/src/components/Paint.module.css
@@ -33,3 +33,13 @@
   cursor: pointer;
   border-color: var(--color3);
 }
+
+.picker {
+  position: relative;
+  display: inline-block;
+  --highlight: var(--color3);
+}
+
+button.showPicker {
+  border-color: var(--color2);
+}

--- a/src/components/Palette.js
+++ b/src/components/Palette.js
@@ -96,6 +96,7 @@ const Palette = ({ updateTool }) => {
   return (
     <Fragment>
       <button
+        type="button"
         ref={editButtonNode}
         className={cx("button", {
           [css.editButton]: editPalette,
@@ -103,7 +104,7 @@ const Palette = ({ updateTool }) => {
         })}
         onClick={() => handleEditClick()}
       >
-        {editPalette ? 'Save' : 'Edit'}
+        {editPalette ? 'Save Palette' : 'Edit Palette'}
       </button>
       <ul
         ref={paletteNode}
@@ -123,6 +124,7 @@ const Palette = ({ updateTool }) => {
         ))}
       </ul>
       <button
+        type="button"
         ref={pickerButtonNode}
         className={cx("button", {
           [css.showPicker]: showPicker && !editPalette,

--- a/src/components/Palette.module.css
+++ b/src/components/Palette.module.css
@@ -49,7 +49,7 @@ button.editButton {
 
 .picker {
   position: relative;
-  --highlight: var(--color4);
+  --highlight: var(--color2);
 }
 
 button.showPicker {

--- a/src/components/Palette.module.css
+++ b/src/components/Palette.module.css
@@ -49,7 +49,7 @@ button.editButton {
 
 .picker {
   position: relative;
-  --highlight: var(--color2);
+  --highlight: var(--color4);
 }
 
 button.showPicker {

--- a/src/components/Resize.js
+++ b/src/components/Resize.js
@@ -15,12 +15,14 @@ const Resizer = ({
       <span className={css.value}>{value}</span>
       <nav className={css.controls}>
         <button
+          type="button"
           className={css.button}
           onClick={increase}
         >
           +
         </button>
         <button
+          type="button"
           className={css.button}
           onClick={decrease}
         >

--- a/src/components/Resize.module.css
+++ b/src/components/Resize.module.css
@@ -7,8 +7,8 @@
 .label {
   display: inline-grid;
   grid-template-areas:
-  "title title"
-  "value controls";
+    "title title"
+    "value controls";
   grid-template-columns: 1fr 36px;
   grid-gap: 0;
   color: var(--color4);
@@ -28,6 +28,8 @@
   grid-area: value;
   display: flex;
   height: 100%;
+  padding-left: 12px;
+  padding-right: 12px;
   align-items: center;
   justify-content: center;
   font-size: 24px;

--- a/src/components/Share.module.css
+++ b/src/components/Share.module.css
@@ -2,6 +2,5 @@
   display: inline-grid;
   grid-template-columns: auto;
   grid-gap: 12px;
-  margin: 12px 0;
   padding: 0;
 }

--- a/src/components/Tool.js
+++ b/src/components/Tool.js
@@ -42,10 +42,10 @@ Brush.propTypes = {
 }
 
 const Tool = ({ tool, updateTool }) => {
-  const shortcutsEnabled = useStore((state) => state.allowShortcuts)
-  useKey('d', () => shortcutsEnabled && updateTool({ type: 'draw' }), {}, [tool, shortcutsEnabled])
-  useKey('f', () => shortcutsEnabled && updateTool({ type: 'fill' }), {}, [tool, shortcutsEnabled])
-  useKey('e', () => shortcutsEnabled && updateTool({ type: 'erase' }), {}, [tool, shortcutsEnabled])
+  useKey('d', () => updateTool({ type: 'draw' }), {}, [tool])
+  useKey('f', () => updateTool({ type: 'fill' }), {}, [tool])
+  useKey('e', () => updateTool({ type: 'erase' }), {}, [tool])
+  
   return (
     <div className={css.tool}>
       <span className="visually-hidden">Current Tool: {tool.type}</span>

--- a/src/components/Toolbar.module.css
+++ b/src/components/Toolbar.module.css
@@ -1,13 +1,17 @@
 .toolbar {
-  padding-left: 24px;
-  padding-right: 24px;
-  z-index: 1;
+  padding-left: 12px;
+  padding-right: 12px;
 }
 
 @media (min-width: 500px) {
   .toolbar {
-    padding: 24px;
     background-color: hsla(0, 0%, 100%, 0.25);
+  }
+}
+
+@media (min-width: 900px) {
+  .toolbar {
+    padding: 24px;
   }
 }
 
@@ -21,6 +25,7 @@
 
 .heading {
   font-size: 18px;
+  margin-top: 24px;
 }
 
 @media (min-width: 500px) {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -49,9 +49,28 @@ const useStore = create(
           return { palette: newPalette }
         }),
 
-      // Allow shortcuts state
-      allowShortcuts: true,
-      setAllowShortcuts: (allowShortcuts) => set({ allowShortcuts }),
+      // EmojiPicker state
+      showPicker: false,
+      setShowPicker: (show) => {
+        set((state) => ({
+          showPicker: show,
+          // disable shortcuts when picker is shown
+          allowShortcuts: !show,
+          // only show picker or edit pallette, not both
+          editPaletteMode: show ? false : state.editPaletteMode
+        }))
+      },
+      // Edit Plalette state
+      editPaletteMode: false,
+      setEditPaletteMode: (edit) => {
+        set((state) => ({
+          editPaletteMode: edit,
+          // disable shortcuts in the edit palette state
+          allowShortcuts: !edit,
+          // only show picker or edit pallette, not both
+          showPicker: edit ? false : state.showPicker
+        }))
+      },
     }), {
       // Cycles to local storage
       name: "emoji-brush",


### PR DESCRIPTION
- splits the emoji picker and palette into 2 components
- removes the 'allow shortcuts' state because the issue with the search bar in the emoji picker doesn't happen anymore
- adds some basic responsive styling