### PR TITLE
Fix emoji picker dismissing on iOS when interacting with search/tabs

### DIFF
--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -26,6 +26,7 @@ const EmojiPicker = ({
       className={cx(css.container, css.emojiPicker, {
         [css.edit]: edit,
       })}
+      onClick={(e) => e.stopPropagation()}
     >
       <Picker
         data={data}

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useEffect } from 'react'
 import cx from 'classnames'
 import Picker from '@emoji-mart/react'
 import data from '@emoji-mart/data'
@@ -16,9 +16,36 @@ interface EmojiObject {
   [key: string]: string
 }
 
-const EmojiPicker = ({ handleEmojiSelect, edit = false }: EmojiPickerProps) => {
+const EmojiPicker = ({
+  handleEmojiSelect,
+  handleClickOutside,
+  edit = false,
+}: EmojiPickerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    // On iOS Safari, clicks inside emoji-mart's shadow DOM produce
+    // unreliable e.target values at the document level. Instead of
+    // inspecting e.target, we stop inside clicks from reaching document,
+    // then treat any click that does reach document as an outside click.
+    const stopPropagation = (e: Event) => e.stopPropagation()
+    el.addEventListener('click', stopPropagation)
+
+    const onDocumentClick = (e: MouseEvent) => handleClickOutside(e)
+    document.addEventListener('click', onDocumentClick)
+
+    return () => {
+      el.removeEventListener('click', stopPropagation)
+      document.removeEventListener('click', onDocumentClick)
+    }
+  }, [handleClickOutside])
+
   return (
     <div
+      ref={containerRef}
       className={cx(css.container, css.emojiPicker, {
         [css.edit]: edit,
       })}

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useEffect } from 'react'
 import cx from 'classnames'
 import Picker from '@emoji-mart/react'
 import data from '@emoji-mart/data'
@@ -21,12 +21,30 @@ const EmojiPicker = ({
   handleClickOutside,
   edit = false,
 }: EmojiPickerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    // Stop click events from bubbling past this container to document,
+    // where emoji-mart's onClickOutside listener lives. On iOS Safari,
+    // shadow DOM event retargeting is unreliable — clicks on search/tabs
+    // inside the picker get misidentified as "outside" clicks. This native
+    // listener fires before the event reaches document, while emoji-mart's
+    // internal handlers (emoji selection, etc.) still work because they're
+    // handled within the shadow DOM before the event crosses the boundary.
+    const stopPropagation = (e: Event) => e.stopPropagation()
+    el.addEventListener('click', stopPropagation)
+    return () => el.removeEventListener('click', stopPropagation)
+  }, [])
+
   return (
     <div
+      ref={containerRef}
       className={cx(css.container, css.emojiPicker, {
         [css.edit]: edit,
       })}
-      onClick={(e) => e.stopPropagation()}
     >
       <Picker
         data={data}

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -1,5 +1,6 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useRef } from 'react'
 import cx from 'classnames'
+import useClickAway from 'react-use/lib/useClickAway'
 import Picker from '@emoji-mart/react'
 import data from '@emoji-mart/data'
 import { Tool } from '@/types'
@@ -23,25 +24,7 @@ const EmojiPicker = ({
 }: EmojiPickerProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    const el = containerRef.current
-    if (!el) return
-
-    // On iOS Safari, clicks inside emoji-mart's shadow DOM produce
-    // unreliable e.target values at the document level. Instead of
-    // inspecting e.target, we stop inside clicks from reaching document,
-    // then treat any click that does reach document as an outside click.
-    const stopPropagation = (e: Event) => e.stopPropagation()
-    el.addEventListener('click', stopPropagation)
-
-    const onDocumentClick = (e: MouseEvent) => handleClickOutside(e)
-    document.addEventListener('click', onDocumentClick)
-
-    return () => {
-      el.removeEventListener('click', stopPropagation)
-      document.removeEventListener('click', onDocumentClick)
-    }
-  }, [handleClickOutside])
+  useClickAway(containerRef, (e) => handleClickOutside(e as MouseEvent))
 
   return (
     <div

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react'
+import React from 'react'
 import cx from 'classnames'
 import Picker from '@emoji-mart/react'
 import data from '@emoji-mart/data'
@@ -16,35 +16,9 @@ interface EmojiObject {
   [key: string]: string
 }
 
-const EmojiPicker = ({
-  handleEmojiSelect,
-  handleClickOutside,
-  edit = false,
-}: EmojiPickerProps) => {
-  const containerRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const el = containerRef.current
-    if (!el) return
-
-    // Handle click-outside detection ourselves instead of relying on
-    // emoji-mart's onClickOutside, which breaks on iOS Safari due to
-    // unreliable shadow DOM event retargeting. Using contains() to check
-    // if the click target is inside our container works reliably across
-    // all browsers regardless of shadow DOM boundaries.
-    const onDocumentClick = (e: MouseEvent) => {
-      if (!el.contains(e.target as Node)) {
-        handleClickOutside(e)
-      }
-    }
-
-    document.addEventListener('click', onDocumentClick)
-    return () => document.removeEventListener('click', onDocumentClick)
-  }, [handleClickOutside])
-
+const EmojiPicker = ({ handleEmojiSelect, edit = false }: EmojiPickerProps) => {
   return (
     <div
-      ref={containerRef}
       className={cx(css.container, css.emojiPicker, {
         [css.edit]: edit,
       })}

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -27,17 +27,20 @@ const EmojiPicker = ({
     const el = containerRef.current
     if (!el) return
 
-    // Stop click events from bubbling past this container to document,
-    // where emoji-mart's onClickOutside listener lives. On iOS Safari,
-    // shadow DOM event retargeting is unreliable — clicks on search/tabs
-    // inside the picker get misidentified as "outside" clicks. This native
-    // listener fires before the event reaches document, while emoji-mart's
-    // internal handlers (emoji selection, etc.) still work because they're
-    // handled within the shadow DOM before the event crosses the boundary.
-    const stopPropagation = (e: Event) => e.stopPropagation()
-    el.addEventListener('click', stopPropagation)
-    return () => el.removeEventListener('click', stopPropagation)
-  }, [])
+    // Handle click-outside detection ourselves instead of relying on
+    // emoji-mart's onClickOutside, which breaks on iOS Safari due to
+    // unreliable shadow DOM event retargeting. Using contains() to check
+    // if the click target is inside our container works reliably across
+    // all browsers regardless of shadow DOM boundaries.
+    const onDocumentClick = (e: MouseEvent) => {
+      if (!el.contains(e.target as Node)) {
+        handleClickOutside(e)
+      }
+    }
+
+    document.addEventListener('click', onDocumentClick)
+    return () => document.removeEventListener('click', onDocumentClick)
+  }, [handleClickOutside])
 
   return (
     <div
@@ -54,7 +57,6 @@ const EmojiPicker = ({
         onEmojiSelect={(emoji: EmojiObject) =>
           handleEmojiSelect({ paint: emoji.native })
         }
-        onClickOutside={handleClickOutside}
         emojiButtonColors={['var(--color2)']}
         theme="light"
       />

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -1,6 +1,5 @@
-import React, { useRef } from 'react'
+import React, { useRef, useEffect } from 'react'
 import cx from 'classnames'
-import useClickAway from 'react-use/lib/useClickAway'
 import Picker from '@emoji-mart/react'
 import data from '@emoji-mart/data'
 import { Tool } from '@/types'
@@ -24,7 +23,26 @@ const EmojiPicker = ({
 }: EmojiPickerProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
 
-  useClickAway(containerRef, (e) => handleClickOutside(e as MouseEvent))
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    // On iOS Safari, clicks inside emoji-mart's shadow DOM produce
+    // unreliable e.target values at the document level, so contains()
+    // checks misfire. Instead, we stop inside clicks from reaching
+    // document, then treat any click that does reach document as an
+    // outside click — no e.target inspection needed.
+    const stopPropagation = (e: Event) => e.stopPropagation()
+    el.addEventListener('click', stopPropagation)
+
+    const onDocumentClick = (e: MouseEvent) => handleClickOutside(e)
+    document.addEventListener('click', onDocumentClick)
+
+    return () => {
+      el.removeEventListener('click', stopPropagation)
+      document.removeEventListener('click', onDocumentClick)
+    }
+  }, [handleClickOutside])
 
   return (
     <div


### PR DESCRIPTION
On iOS Safari, click events originating inside the emoji-mart shadow DOM
don't properly retarget e.target to the shadow host when bubbling to
document. This causes emoji-mart's document-level click-outside detector
to incorrectly fire onClickOutside for clicks within the picker (search,
tabs, skin tone selector). Stopping click propagation at the wrapper div
prevents these internal clicks from reaching the document listener while
preserving all picker functionality handled within the shadow DOM.

https://claude.ai/code/session_01HeydVEsALpHVjVAjEAEKDD