### PR TITLE
Replace native scroll with pan/pinch/zoom viewport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,11 @@
         "emoji-mart": "^5.6.0",
         "jest-extended": "^4.0.2",
         "lodash": "^4.17.21",
-        "next": "15.2.2",
+        "next": "15.2.8",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-use": "^17.6.0",
+        "react-zoom-pan-pinch": "^4.0.3",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -1648,9 +1649,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.2.tgz",
-      "integrity": "sha512-yWgopCfA9XDR8ZH3taB5nRKtKJ1Q5fYsTOuYkzIIoS8TJ0UAUKAGF73JnGszbjk2ufAQDj6mDdgsJAFx5CLtYQ==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.8.tgz",
+      "integrity": "sha512-TaEsAki14R7BlgywA05t2PFYfwZiNlGUHyIQHVyloXX3y+Dm0HUITe5YwTkjtuOQuDhuuLotNEad4VtnmE11Uw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1664,9 +1665,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.2.tgz",
-      "integrity": "sha512-HNBRnz+bkZ+KfyOExpUxTMR0Ow8nkkcE6IlsdEa9W/rI7gefud19+Sn1xYKwB9pdCdxIP1lPru/ZfjfA+iT8pw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.5.tgz",
+      "integrity": "sha512-4OimvVlFTbgzPdA0kh8A1ih6FN9pQkL4nPXGqemEYgk+e7eQhsst/p35siNNqA49eQA6bvKZ1ASsDtu9gtXuog==",
       "cpu": [
         "arm64"
       ],
@@ -1680,9 +1681,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.2.tgz",
-      "integrity": "sha512-mJOUwp7al63tDpLpEFpKwwg5jwvtL1lhRW2fI1Aog0nYCPAhxbJsaZKdoVyPZCy8MYf/iQVNDuk/+i29iLCzIA==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.5.tgz",
+      "integrity": "sha512-ohzRaE9YbGt1ctE0um+UGYIDkkOxHV44kEcHzLqQigoRLaiMtZzGrA11AJh2Lu0lv51XeiY1ZkUvkThjkVNBMA==",
       "cpu": [
         "x64"
       ],
@@ -1696,9 +1697,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.2.tgz",
-      "integrity": "sha512-5ZZ0Zwy3SgMr7MfWtRE7cQWVssfOvxYfD9O7XHM7KM4nrf5EOeqwq67ZXDgo86LVmffgsu5tPO57EeFKRnrfSQ==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.5.tgz",
+      "integrity": "sha512-FMSdxSUt5bVXqqOoZCc/Seg4LQep9w/fXTazr/EkpXW2Eu4IFI9FD7zBDlID8TJIybmvKk7mhd9s+2XWxz4flA==",
       "cpu": [
         "arm64"
       ],
@@ -1712,9 +1713,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.2.tgz",
-      "integrity": "sha512-cgKWBuFMLlJ4TWcFHl1KOaVVUAF8vy4qEvX5KsNd0Yj5mhu989QFCq1WjuaEbv/tO1ZpsQI6h/0YR8bLwEi+nA==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.5.tgz",
+      "integrity": "sha512-4ZNKmuEiW5hRKkGp2HWwZ+JrvK4DQLgf8YDaqtZyn7NYdl0cHfatvlnLFSWUayx9yFAUagIgRGRk8pFxS8Qniw==",
       "cpu": [
         "arm64"
       ],
@@ -1728,9 +1729,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.2.tgz",
-      "integrity": "sha512-c3kWSOSsVL8rcNBBfOq1+/j2PKs2nsMwJUV4icUxRgGBwUOfppeh7YhN5s79enBQFU+8xRgVatFkhHU1QW7yUA==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.5.tgz",
+      "integrity": "sha512-bE6lHQ9GXIf3gCDE53u2pTl99RPZW5V1GLHSRMJ5l/oB/MT+cohu9uwnCK7QUph2xIOu2a6+27kL0REa/kqwZw==",
       "cpu": [
         "x64"
       ],
@@ -1744,9 +1745,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.2.tgz",
-      "integrity": "sha512-PXTW9PLTxdNlVYgPJ0equojcq1kNu5NtwcNjRjHAB+/sdoKZ+X8FBu70fdJFadkxFIGekQTyRvPMFF+SOJaQjw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.5.tgz",
+      "integrity": "sha512-y7EeQuSkQbTAkCEQnJXm1asRUuGSWAchGJ3c+Qtxh8LVjXleZast8Mn/rL7tZOm7o35QeIpIcid6ufG7EVTTcA==",
       "cpu": [
         "x64"
       ],
@@ -1760,9 +1761,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.2.tgz",
-      "integrity": "sha512-nG644Es5llSGEcTaXhnGWR/aThM/hIaz0jx4MDg4gWC8GfTCp8eDBWZ77CVuv2ha/uL9Ce+nPTfYkSLG67/sHg==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.5.tgz",
+      "integrity": "sha512-gQMz0yA8/dskZM2Xyiq2FRShxSrsJNha40Ob/M2n2+JGRrZ0JwTVjLdvtN6vCxuq4ByhOd4a9qEf60hApNR2gQ==",
       "cpu": [
         "arm64"
       ],
@@ -1776,9 +1777,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.2.tgz",
-      "integrity": "sha512-52nWy65S/R6/kejz3jpvHAjZDPKIbEQu4x9jDBzmB9jJfuOy5rspjKu4u77+fI4M/WzLXrrQd57hlFGzz1ubcQ==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.5.tgz",
+      "integrity": "sha512-tBDNVUcI7U03+3oMvJ11zrtVin5p0NctiuKmTGyaTIEAVj9Q77xukLXGXRnWxKRIIdFG4OTA2rUVGZDYOwgmAA==",
       "cpu": [
         "x64"
       ],
@@ -7111,12 +7112,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.2.2.tgz",
-      "integrity": "sha512-dgp8Kcx5XZRjMw2KNwBtUzhngRaURPioxoNIVl5BOyJbhi9CUgEtKDO7fx5wh8Z8vOVX1nYZ9meawJoRrlASYA==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.2.8.tgz",
+      "integrity": "sha512-pe2trLKZTdaCuvNER0S9Wp+SP2APf7SfFmyUP9/w1SFA2UqmW0u+IsxCKkiky3n6um7mryaQIlgiDnKrf1ZwIw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.2.2",
+        "@next/env": "15.2.8",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -7131,14 +7132,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.2.2",
-        "@next/swc-darwin-x64": "15.2.2",
-        "@next/swc-linux-arm64-gnu": "15.2.2",
-        "@next/swc-linux-arm64-musl": "15.2.2",
-        "@next/swc-linux-x64-gnu": "15.2.2",
-        "@next/swc-linux-x64-musl": "15.2.2",
-        "@next/swc-win32-arm64-msvc": "15.2.2",
-        "@next/swc-win32-x64-msvc": "15.2.2",
+        "@next/swc-darwin-arm64": "15.2.5",
+        "@next/swc-darwin-x64": "15.2.5",
+        "@next/swc-linux-arm64-gnu": "15.2.5",
+        "@next/swc-linux-arm64-musl": "15.2.5",
+        "@next/swc-linux-x64-gnu": "15.2.5",
+        "@next/swc-linux-x64-musl": "15.2.5",
+        "@next/swc-win32-arm64-msvc": "15.2.5",
+        "@next/swc-win32-x64-msvc": "15.2.5",
         "sharp": "^0.33.5"
       },
       "peerDependencies": {
@@ -7834,6 +7835,20 @@
         "throttle-debounce": "^3.0.1",
         "ts-easing": "^0.2.0",
         "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-4.0.3.tgz",
+      "integrity": "sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
       },
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
     "emoji-mart": "^5.6.0",
     "jest-extended": "^4.0.2",
     "lodash": "^4.17.21",
-    "next": "15.2.2",
+    "next": "15.2.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-use": "^17.6.0",
+    "react-zoom-pan-pinch": "^4.0.3",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,9 +4,26 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'EmojiBrush',
-  description: 'Make art for your friends (and enemies) with Emojis',
+  title: 'EmojiBrush - Create Emoji Art',
+  description: 'Create beautiful Emoji art for your friends and enemies',
   metadataBase: new URL('https://emojibru.sh'), // @todo: add env vars to handle this
+  keywords: [
+    'emoji art',
+    'emoji creator',
+    'emoji drawing',
+    'online emoji art tool',
+    'creative emoji',
+    'digital emoji art',
+    'emoji canvas',
+  ],
+  creator: 'Brant Hardy',
+  alternates: {
+    canonical: 'https://emojibru.sh',
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 }
 
 export default function RootLayout({

--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -8,7 +8,7 @@
   grid-template-columns: auto;
   grid-template-rows: auto 1fr auto;
   width: 100%;
-  min-height: 100%;
+  height: 100%;
 }
 
 @media (min-width: 500px) {
@@ -21,6 +21,8 @@
     grid-template-columns: 1fr repeat(2, 240px) 1fr;
     grid-template-rows: auto 1fr auto auto;
     grid-gap: 8px;
+    height: auto;
+    min-height: 100%;
   }
 }
 

--- a/src/components/Artboard.module.css
+++ b/src/components/Artboard.module.css
@@ -1,9 +1,10 @@
 .artboard {
   grid-area: artboard;
-  overflow: auto;
+  overflow: hidden;
   display: flex;
+  position: relative;
   padding-bottom: 10px;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 }
 
 @media (min-width: 500px) {

--- a/src/components/Artboard.tsx
+++ b/src/components/Artboard.tsx
@@ -9,7 +9,6 @@ import css from './Artboard.module.css'
 const Artboard = () => {
   const painting = useStore((state) => state.painting)
   const setPainting = useStore((state) => state.setPainting)
-  const tool = useStore((state) => state.tool)
 
   const handleUpdatePainting = (update: Partial<Painting>) => {
     setPainting(update)
@@ -26,8 +25,13 @@ const Artboard = () => {
     }
   }, [painting, setPainting])
 
+  // Read the tool live at call time. A render-time closure over `tool` can be
+  // stale during fast iOS pinches: the temporary-pan setTool fires from a
+  // native touch listener but React 19 may not have flushed the re-render
+  // before the next touch event dispatches the synthetic onTouchEnd.
   const paint = (row: number, col: number) => {
-    switch (tool.type) {
+    const currentTool = useStore.getState().tool
+    switch (currentTool.type) {
       case 'draw':
         draw(row, col)
         break
@@ -43,7 +47,7 @@ const Artboard = () => {
   }
 
   const emojiChar = () => {
-    const paint = tool.paint
+    const paint = useStore.getState().tool.paint
     return `${paint}${String.fromCharCode(65039)}`
   }
 

--- a/src/components/Canvas.module.css
+++ b/src/components/Canvas.module.css
@@ -1,5 +1,18 @@
-.center {
-  margin: auto;
+.viewport {
+  flex: 1;
+  align-self: stretch;
+  position: relative;
+  overflow: hidden;
+  touch-action: none;
+  overscroll-behavior: contain;
+}
+
+.viewport[data-pan='true'] {
+  cursor: grab;
+}
+
+.viewport[data-pan='true']:active {
+  cursor: grabbing;
 }
 
 .wrapper {
@@ -8,13 +21,10 @@
   background-color: var(--white);
   border-radius: 12px;
   box-shadow: 0 0 8px 8px var(--white);
-  /* @note: this offsets the box-shadow, if you change it, you should override the white variable with something easier to see */
-  margin: 16px;
 }
 
 @media (min-width: 500px) {
   .wrapper {
     box-shadow: 0 0 16px 16px var(--white);
-    margin: 32px;
   }
 }

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -1,23 +1,20 @@
+import { useEffect, useRef, RefObject } from 'react'
 import {
-  useEffect,
-  useRef,
-  RefObject,
-  MouseEvent as ReactMouseEvent,
-  TouchEvent as ReactTouchEvent,
-} from 'react'
+  TransformWrapper,
+  TransformComponent,
+  ReactZoomPanPinchContentRef,
+} from 'react-zoom-pan-pinch'
 import { useDrawingStatus } from '../hooks/useDrawingStatus'
+import { useCanvasViewport } from '../hooks/useCanvasViewport'
+import useStore from '../store/store'
 import { Painting } from '@/types'
 import css from './Canvas.module.css'
 
-type DrawFunctionType = (y: number, x: number) => void
-type DrawEventType =
-  | ReactMouseEvent<HTMLCanvasElement>
-  | ReactTouchEvent<HTMLCanvasElement>
 type CanvasRefType = RefObject<HTMLCanvasElement | null>
 
-// retina -- times 2
-const R = 2
-// multiplier -- cell size
+// pixel-density factor; higher = sharper at zoom but more memory
+const R = 4
+// multiplier -- cell size in canvas pixels
 const MP = 32 * R
 // offset -- buffer
 const OS = 4 * R
@@ -40,55 +37,37 @@ const drawing = (canvasRef: CanvasRefType, grid: Painting['grid']) => {
     })
   })
 
-  // restores the translation to 0,0
   ctx.restore()
 }
 
-const getRelativePosition = (canvasRef: CanvasRefType, e: DrawEventType) => {
+const getCellFromEvent = (
+  canvasRef: CanvasRefType,
+  e: TouchEvent | MouseEvent,
+  width: number,
+  height: number,
+) => {
   const canvas = canvasRef.current
   if (!canvas) return { cx: -1, cy: -1 }
   const rect = canvas.getBoundingClientRect()
 
-  // grab either the touch events (if they exist) or the mouse events
-  const x =
-    'touches' in e
-      ? e.touches[0]?.clientX ||
-        (e as ReactTouchEvent<HTMLCanvasElement>).changedTouches[0]?.clientX
-      : (e as ReactMouseEvent<HTMLCanvasElement>).clientX
-  const y =
-    'touches' in e
-      ? e.touches[0]?.clientY ||
-        (e as ReactTouchEvent<HTMLCanvasElement>).changedTouches[0]?.clientY
-      : (e as ReactMouseEvent<HTMLCanvasElement>).clientY
+  let clientX: number | undefined
+  let clientY: number | undefined
+  if ('touches' in e) {
+    const t = e.touches[0] || e.changedTouches[0]
+    clientX = t?.clientX
+    clientY = t?.clientY
+  } else {
+    clientX = (e as MouseEvent).clientX
+    clientY = (e as MouseEvent).clientY
+  }
+  if (clientX === undefined || clientY === undefined)
+    return { cx: -1, cy: -1 }
 
-  // clicked cell (zero-indexed)
-  const cx = Math.ceil(((x - rect.left) / MP) * R) - 1
-  const cy = Math.ceil(((y - rect.top) / MP) * R) - 1
-
+  // rect already reflects react-zoom-pan-pinch's CSS transform, so a 0..1
+  // ratio against rect.width/height gives the correct cell.
+  const cx = Math.floor(((clientX - rect.left) / rect.width) * width)
+  const cy = Math.floor(((clientY - rect.top) / rect.height) * height)
   return { cx, cy }
-}
-
-const handleCanvasClick = (
-  canvasRef: CanvasRefType,
-  e: DrawEventType,
-  draw: DrawFunctionType,
-) => {
-  const { cx, cy } = getRelativePosition(canvasRef, e)
-  if (cx >= 0 && cy >= 0) {
-    draw(cy, cx)
-  }
-}
-
-const handleCanvasDrag = (
-  canvasRef: CanvasRefType,
-  e: DrawEventType,
-  draw: DrawFunctionType,
-  isDrawing: boolean,
-) => {
-  const { cx, cy } = getRelativePosition(canvasRef, e)
-  if (isDrawing && cx >= 0 && cy >= 0) {
-    draw(cy, cx)
-  }
 }
 
 interface CanvasProps extends Painting {
@@ -97,33 +76,165 @@ interface CanvasProps extends Painting {
 
 const Canvas = ({ grid, draw, width, height }: CanvasProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const viewportRef = useRef<HTMLDivElement>(null)
   const isDrawing = useDrawingStatus(canvasRef)
+  const isDrawingRef = useRef(isDrawing)
+  isDrawingRef.current = isDrawing
+  const drawRef = useRef(draw)
+  drawRef.current = draw
+  const widthRef = useRef(width)
+  widthRef.current = width
+  const heightRef = useRef(height)
+  heightRef.current = height
+
+  const tool = useStore((state) => state.tool)
+  const isPanning = tool.type === 'pan'
+
+  const { enterPanFromGesture, exitPanIfAllTouchesUp } =
+    useCanvasViewport(viewportRef)
+
+  const transformRef = useRef<ReactZoomPanPinchContentRef>(null)
+
+  // Fit the painting to the viewport on mount and whenever the painting is
+  // resized. Scales down (never up) so a big painting fits the screen and a
+  // small one stays at natural pixel size. `requestAnimationFrame` retries
+  // while initial layout is still settling (iOS reports 0 for clientHeight
+  // until paint completes).
+  useEffect(() => {
+    let raf = 0
+    const fit = () => {
+      const wrapper = transformRef.current
+      const viewport = viewportRef.current
+      // The canvas's parent is our .wrapper div — the actual transformable
+      // content. offsetWidth/Height is the layout (pre-transform) box.
+      const content = canvasRef.current?.parentElement
+      if (!wrapper || !viewport || !content) return
+      const vw = viewport.clientWidth
+      const vh = viewport.clientHeight
+      const cw = content.offsetWidth
+      const ch = content.offsetHeight
+      if (!vw || !vh || !cw || !ch) {
+        raf = requestAnimationFrame(fit)
+        return
+      }
+      const fitScale = Math.min(vw / cw, vh / ch, 1)
+      wrapper.centerView(fitScale, 0)
+    }
+    raf = requestAnimationFrame(fit)
+    return () => cancelAnimationFrame(raf)
+  }, [width, height])
+
+  // Native drawing listeners on the canvas. These fire in target phase,
+  // before react-zoom-pan-pinch's bubble-phase callbacks restore the tool,
+  // so a touchend mid-pinch never sees the freshly-restored tool. The
+  // listener also reads tool live via useStore.getState() so a stale React
+  // closure can't draw during a pinch either.
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const isPan = () => useStore.getState().tool.type === 'pan'
+
+    const handleClick = (e: TouchEvent | MouseEvent) => {
+      if (isPan()) return
+      const { cx, cy } = getCellFromEvent(
+        canvasRef,
+        e,
+        widthRef.current,
+        heightRef.current,
+      )
+      if (cx >= 0 && cy >= 0) drawRef.current(cy, cx)
+    }
+    const handleDrag = (e: TouchEvent | MouseEvent) => {
+      if (isPan()) return
+      if (!isDrawingRef.current) return
+      const { cx, cy } = getCellFromEvent(
+        canvasRef,
+        e,
+        widthRef.current,
+        heightRef.current,
+      )
+      if (cx >= 0 && cy >= 0) drawRef.current(cy, cx)
+    }
+
+    canvas.addEventListener('touchend', handleClick)
+    canvas.addEventListener('touchmove', handleDrag)
+    canvas.addEventListener('mousedown', handleClick)
+    canvas.addEventListener('mousemove', handleDrag)
+    return () => {
+      canvas.removeEventListener('touchend', handleClick)
+      canvas.removeEventListener('touchmove', handleDrag)
+      canvas.removeEventListener('mousedown', handleClick)
+      canvas.removeEventListener('mousemove', handleDrag)
+    }
+  }, [])
 
   useEffect(() => {
     drawing(canvasRef, grid)
   }, [width, height, grid])
 
-  // @note: the style is 1/2 the width & height for retina
   const pixelSize = {
     width: width * MP,
     height: height * MP,
   }
 
   return (
-    <div className={css.center}>
-      <div className={css.wrapper}>
-        <canvas
-          id="emojibrush-canvas"
-          ref={canvasRef}
-          width={pixelSize.width}
-          height={pixelSize.height}
-          style={{ width: pixelSize.width / 2, height: pixelSize.height / 2 }}
-          onMouseDown={(e) => handleCanvasClick(canvasRef, e, draw)}
-          onTouchEnd={(e) => handleCanvasClick(canvasRef, e, draw)}
-          onMouseMove={(e) => handleCanvasDrag(canvasRef, e, draw, isDrawing)}
-          onTouchMove={(e) => handleCanvasDrag(canvasRef, e, draw, isDrawing)}
-        />
-      </div>
+    <div
+      ref={viewportRef}
+      className={css.viewport}
+      data-pan={isPanning ? 'true' : 'false'}
+    >
+      <TransformWrapper
+        ref={transformRef}
+        initialScale={1}
+        minScale={0.1}
+        maxScale={2}
+        centerOnInit
+        limitToBounds={false}
+        // autoAlignment runs after every wheel-zoom (via
+        // handleAlignToScaleBounds → handleAlignToBounds → animate), nudging
+        // the canvas back toward the library's internal bounds even with
+        // limitToBounds=false. That manifested as the canvas drifting on its
+        // own after a zoom. Disable.
+        autoAlignment={{ disabled: true }}
+        doubleClick={{ disabled: true }}
+        panning={{
+          disabled: !isPanning,
+          velocityDisabled: true,
+        }}
+        pinch={{ disabled: false }}
+        wheel={{
+          // Wheel zoom is always available so users can zoom regardless of
+          // the active tool. Only mouse-drag panning is gated by isPanning.
+          disabled: false,
+          // step multiplies |event.deltaY| each wheel tick (lib default
+          // smooth=true). 0.1 is the lib's documented default and is far
+          // too fast on a regular mouse wheel where deltaY ~ 100/tick.
+          step: 0.025,
+        }}
+        onPinchStart={enterPanFromGesture}
+        onPinchStop={(_, event) => {
+          exitPanIfAllTouchesUp(event.touches.length)
+        }}
+      >
+        {/* The TransformComponent wrapper fills our viewport so the library
+            can clip / position; the content stays fit-content so the white
+            .wrapper sizes exactly to the canvas + padding. */}
+        <TransformComponent wrapperStyle={{ width: '100%', height: '100%' }}>
+          <div className={css.wrapper}>
+            <canvas
+              id="emojibrush-canvas"
+              ref={canvasRef}
+              width={pixelSize.width}
+              height={pixelSize.height}
+              style={{
+                width: pixelSize.width / R,
+                height: pixelSize.height / R,
+              }}
+            />
+          </div>
+        </TransformComponent>
+      </TransformWrapper>
     </div>
   )
 }

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -2,8 +2,9 @@ import React, { forwardRef } from 'react'
 import cx from 'classnames'
 import useKey from 'react-use/lib/useKey'
 import { Tool } from '@/types'
-import css from './ColorPicker.module.css'
+import useStore from '@/store/store'
 
+import css from './ColorPicker.module.css'
 interface ColorPickerProps {
   tool: Tool
   updateTool: (update: Partial<Tool>) => void
@@ -21,9 +22,18 @@ const ColorPicker = forwardRef<HTMLDivElement, ColorPickerProps>(
 
     useKey('x', handleSwap, {}, [tool])
 
+    // @note: clicking active swatch opens color picker
+    const showPicker = useStore((state) => state.showPicker)
+    const setShowPicker = useStore((state) => state.setShowPicker)
+
     return (
       <div className={cx(css.colorPicker, { [css.mini]: mini })} ref={ref}>
-        <div className={cx(css.swatch, css.active)}>{tool.paint}</div>
+        <div
+          className={cx(css.swatch, css.active)}
+          onClick={() => setShowPicker(!showPicker)}
+        >
+          {tool.paint}
+        </div>
         <div
           className={cx(css.swatch, css.alternate)}
           onClick={() => handleSwap()}

--- a/src/components/EmojiPicker.module.css
+++ b/src/components/EmojiPicker.module.css
@@ -1,9 +1,8 @@
 /* @todo: move these container rules to the consuming components */
 .container {
   position: fixed;
-  top: 50px;
+  top: 72px;
   left: 50%;
-  z-index: 99;
   transform: translateX(-50%);
   z-index: 101; /* this has to be above topLayer */
 }

--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useEffect } from 'react'
 import cx from 'classnames'
 import Picker from '@emoji-mart/react'
 import data from '@emoji-mart/data'
@@ -21,8 +21,32 @@ const EmojiPicker = ({
   handleClickOutside,
   edit = false,
 }: EmojiPickerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    // On iOS Safari, clicks inside emoji-mart's shadow DOM produce
+    // unreliable e.target values at the document level, so contains()
+    // checks misfire. Instead, we stop inside clicks from reaching
+    // document, then treat any click that does reach document as an
+    // outside click — no e.target inspection needed.
+    const stopPropagation = (e: Event) => e.stopPropagation()
+    el.addEventListener('click', stopPropagation)
+
+    const onDocumentClick = (e: MouseEvent) => handleClickOutside(e)
+    document.addEventListener('click', onDocumentClick)
+
+    return () => {
+      el.removeEventListener('click', stopPropagation)
+      document.removeEventListener('click', onDocumentClick)
+    }
+  }, [handleClickOutside])
+
   return (
     <div
+      ref={containerRef}
       className={cx(css.container, css.emojiPicker, {
         [css.edit]: edit,
       })}
@@ -35,7 +59,6 @@ const EmojiPicker = ({
         onEmojiSelect={(emoji: EmojiObject) =>
           handleEmojiSelect({ paint: emoji.native })
         }
-        onClickOutside={handleClickOutside}
         emojiButtonColors={['var(--color2)']}
         theme="light"
       />

--- a/src/components/Footer.module.css
+++ b/src/components/Footer.module.css
@@ -1,6 +1,5 @@
 .footer {
   grid-area: footer;
-  padding: 16px;
   text-align: center;
 }
 
@@ -8,8 +7,16 @@
   font-size: 12px;
 }
 
+.footer p:nth-of-type(2) {
+  display: none;
+}
+
 @media (min-width: 500px) {
   .footer {
     padding: 24px;
+  }
+
+  .footer p:nth-of-type(2) {
+    display: block;
   }
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,7 +16,7 @@ const Footer = () => (
       >
         Brant Hardy
       </a>
-      . Copyright &copy;&nbsp;{new Date().getFullYear()}
+      .
     </p>
     <p>
       File{' '}

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -7,8 +7,21 @@
 .heading {
   display: flex;
   justify-content: center;
-  align-content: center;
+  align-items: center;
   color: var(--color4);
+  font-size: 20px;
+}
+
+@media (min-width: 500px) {
+  .heading {
+    font-size: 24px;
+  }
+}
+
+@media (min-width: 900px) {
+  .heading {
+    font-size: 32px;
+  }
 }
 
 .logo {

--- a/src/components/SmallScreenToolbar.module.css
+++ b/src/components/SmallScreenToolbar.module.css
@@ -43,16 +43,6 @@
   font-size: 12px;
 }
 
-.panTool {
-  display: none;
-}
-
-@media (hover: none) and (pointer: coarse) {
-  .panTool {
-    display: block;
-  }
-}
-
 .buttonFlexContainer {
   display: flex;
   flex-direction: column;
@@ -86,10 +76,24 @@
   border: 2px solid var(--color3);
   box-shadow: 4px 4px 0 0 var(--color4);
   font-size: 12px;
+  z-index: 2;
 }
 
 @media (min-width: 500px) {
   .menuButton {
+    display: none;
+  }
+}
+
+.picker {
+  grid-column: 1 / -1;
+  grid-row: 1 / -3;
+  z-index: 1;
+  --highlight: var(--color2);
+}
+
+@media (min-width: 500px) {
+  .picker {
     display: none;
   }
 }

--- a/src/components/SmallScreenToolbar.tsx
+++ b/src/components/SmallScreenToolbar.tsx
@@ -3,6 +3,7 @@ import useStore from '../store/store'
 import { Tool as ToolType } from '@/types'
 import ColorPicker from './ColorPicker'
 import css from './SmallScreenToolbar.module.css'
+import EmojiPicker from './EmojiPicker'
 
 interface ToolProps {
   currentTool: ToolType
@@ -38,6 +39,9 @@ const SmallScreenToolbar = () => {
     (state) => state.setShowExpandedToolbar,
   )
   const showExpandedToolbar = useStore((state) => state.showExpandedToolbar)
+  const showPicker = useStore((state) => state.showPicker)
+  const setShowPicker = useStore((state) => state.setShowPicker)
+
   return (
     <>
       <nav
@@ -72,7 +76,7 @@ const SmallScreenToolbar = () => {
               updateTool={updateTool}
             />
           </li>
-          <li className={css.panTool}>
+          <li>
             <Tool
               type="pan"
               icon="🤚"
@@ -84,6 +88,14 @@ const SmallScreenToolbar = () => {
         </ul>
         <ColorPicker tool={tool} updateTool={updateTool} mini />
       </nav>
+      {showPicker && (
+        <div className={css.picker}>
+          <EmojiPicker
+            handleEmojiSelect={updateTool}
+            handleClickOutside={() => setShowPicker(false)}
+          />
+        </div>
+      )}
       {/* @todo: consider combining with below */}
       {!showExpandedToolbar ? (
         <button

--- a/src/components/Tool.module.css
+++ b/src/components/Tool.module.css
@@ -22,16 +22,6 @@
   border-color: var(--color3);
 }
 
-.label-pan {
-  display: none;
-}
-
-@media (hover: none) and (pointer: coarse) {
-  .label-pan {
-    display: grid;
-  }
-}
-
 .activeLabel,
 .activeLabel:hover,
 .activeLabel:focus {

--- a/src/components/Tool.tsx
+++ b/src/components/Tool.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import cx from 'classnames'
 import useKey from 'react-use/lib/useKey'
+import useStore from '../store/store'
 import { Tool as ToolType } from '@/types'
 import css from './Tool.module.css'
 
@@ -40,13 +41,71 @@ interface ToolsProps {
   updateTool: (update: Partial<ToolType>) => void
 }
 
+const TEXT_INPUT_TYPES = new Set([
+  'text',
+  'search',
+  'email',
+  'url',
+  'tel',
+  'password',
+  'number',
+])
+
+const isTextInputFocused = () => {
+  const el = typeof document !== 'undefined' ? document.activeElement : null
+  if (!el) return false
+  if ((el as HTMLElement).isContentEditable) return true
+  const tag = el.tagName.toLowerCase()
+  if (tag === 'textarea') return true
+  if (tag === 'input') {
+    // Only text-like input types swallow space. The tool radios get focus
+    // when clicked; without this filter every tool-switch would disable
+    // spacebar-hold-to-pan until the user clicked elsewhere.
+    const type = ((el as HTMLInputElement).type || '').toLowerCase()
+    return TEXT_INPUT_TYPES.has(type)
+  }
+  return false
+}
+
 const Tools = ({ tool, updateTool }: ToolsProps) => {
   useKey('d', () => updateTool({ type: 'draw' }), {}, [tool])
   useKey('f', () => updateTool({ type: 'fill' }), {}, [tool])
   useKey('e', () => updateTool({ type: 'erase' }), {}, [tool])
-  // @note: since we hide the pan tool in some cases we need better conditional
-  // logic before enabling the shortcut
-  // useKey(' ', () => updateTool({ type: 'pan' }), {}, [tool])
+
+  // Hold spacebar to enter pan mode; release to restore the previous tool.
+  // Direct window listeners (vs react-use's useKey) so we have control over
+  // preventDefault — without it, spacebar scrolls the page. Also avoids
+  // useKey's memoised handler closing over a stale `updateTool` reference if
+  // the parent ever swaps it. Tool state is read live via useStore.getState()
+  // so we save the actual current tool, not a stale closure.
+  const spacePrevToolRef = useRef<ToolType['type'] | null>(null)
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== ' ') return
+      if (e.repeat) return
+      if (isTextInputFocused()) return
+      if (spacePrevToolRef.current !== null) return
+      const current = useStore.getState().tool
+      if (current.type === 'pan') return
+      e.preventDefault()
+      spacePrevToolRef.current = current.type
+      updateTool({ type: 'pan' })
+    }
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key !== ' ') return
+      if (spacePrevToolRef.current === null) return
+      e.preventDefault()
+      const restore = spacePrevToolRef.current
+      spacePrevToolRef.current = null
+      updateTool({ type: restore })
+    }
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
+    }
+  }, [updateTool])
 
   return (
     <div className={css.tool}>

--- a/src/components/Toolbar.module.css
+++ b/src/components/Toolbar.module.css
@@ -5,9 +5,10 @@
 @media (max-width: 499px) {
   .toolbar.visible {
     display: grid;
-    grid-template-columns: 1fr;
-    grid-column: 1 / -1;
-    grid-row: 2 / -1;
+    position: absolute;
+    top: 72px;
+    left: 0;
+    right: 0;
     grid-template-areas:
       'primary-tools'
       'secondary-tools';

--- a/src/hooks/useCanvasViewport.ts
+++ b/src/hooks/useCanvasViewport.ts
@@ -1,0 +1,128 @@
+import { useEffect, useRef, RefObject } from 'react'
+import useStore from '@/store/store'
+import { Tool } from '@/types'
+
+const SYNTH_MOUSE_WINDOW_MS = 600
+
+/**
+ * Layered around react-zoom-pan-pinch's gesture detection. Owns:
+ * - Multi-touch detection on touchstart so a fast 2-finger pinch (one that
+ *   doesn't trip the library's movement threshold) still flips the tool to
+ *   `pan` for the duration of the gesture.
+ * - Restoring the previous tool when all fingers lift.
+ * - Swallowing the mouse / pointer events iOS synthesizes after touchend so
+ *   they don't reach the canvas's native drawing listeners (which see
+ *   pointerType='mouse' as a real mouse interaction otherwise).
+ *
+ * Returns idempotent enter/exit helpers so the library's onPinchStart /
+ * onPinchStop can also drive the same state machine without duplicating it.
+ */
+export const useCanvasViewport = (
+  viewportRef: RefObject<HTMLElement | null>,
+) => {
+  const setTool = useStore((state) => state.setTool)
+  const previousToolRef = useRef<Tool['type'] | null>(null)
+
+  // Idempotent so both our multi-touch listener and the library's onPinchStart
+  // can call it without double-saving the tool.
+  const enterPanFromGesture = () => {
+    if (previousToolRef.current !== null) return
+    const current = useStore.getState().tool
+    if (current.type === 'pan') return
+    previousToolRef.current = current.type
+    setTool({ type: 'pan' })
+  }
+
+  const exitPanIfAllTouchesUp = (remainingTouches: number) => {
+    if (remainingTouches > 0) return
+    if (previousToolRef.current === null) return
+    setTool({ type: previousToolRef.current })
+    previousToolRef.current = null
+  }
+
+  useEffect(() => {
+    const viewport = viewportRef.current
+    if (!viewport) return
+
+    let lastTouchAt = 0
+
+    const onTouchStart = (e: TouchEvent) => {
+      lastTouchAt = Date.now()
+      // 2+ fingers means a pinch / 2-finger pan even if the library hasn't
+      // recognised it yet (its onPinchStart only fires after a movement
+      // threshold). Flip to pan immediately.
+      if (e.touches.length >= 2) enterPanFromGesture()
+    }
+    const onTouchMoveOrEnd = (e: TouchEvent) => {
+      lastTouchAt = Date.now()
+      if (e.type === 'touchend' || e.type === 'touchcancel') {
+        exitPanIfAllTouchesUp(e.touches.length)
+      }
+    }
+
+    // iOS dispatches synthesized mouse events (mousedown/mouseup/click) and
+    // synthesized pointer events with pointerType='mouse' a few frames after
+    // the final touchend. Capture-phase + stopImmediatePropagation kills
+    // them before any drawing handler or the library's pointer handlers see
+    // them. Real touch-driven pointer events fire with pointerType='touch'
+    // and are explicitly let through.
+    const swallowSynthMouse = (e: Event) => {
+      if ('pointerType' in e && (e as PointerEvent).pointerType !== 'mouse') {
+        return
+      }
+      if (Date.now() - lastTouchAt < SYNTH_MOUSE_WINDOW_MS) {
+        e.stopImmediatePropagation()
+        if (e.cancelable) e.preventDefault()
+      }
+    }
+
+    viewport.addEventListener('touchstart', onTouchStart, { passive: true })
+    viewport.addEventListener('touchmove', onTouchMoveOrEnd, { passive: true })
+    viewport.addEventListener('touchend', onTouchMoveOrEnd, { passive: true })
+    viewport.addEventListener('touchcancel', onTouchMoveOrEnd, {
+      passive: true,
+    })
+    const captureOpts = { capture: true } as AddEventListenerOptions
+    viewport.addEventListener('mousedown', swallowSynthMouse, captureOpts)
+    viewport.addEventListener('mouseup', swallowSynthMouse, captureOpts)
+    viewport.addEventListener('click', swallowSynthMouse, captureOpts)
+    viewport.addEventListener('pointerdown', swallowSynthMouse, captureOpts)
+    viewport.addEventListener('pointermove', swallowSynthMouse, captureOpts)
+    viewport.addEventListener('pointerup', swallowSynthMouse, captureOpts)
+    viewport.addEventListener('pointercancel', swallowSynthMouse, captureOpts)
+    return () => {
+      viewport.removeEventListener('touchstart', onTouchStart)
+      viewport.removeEventListener('touchmove', onTouchMoveOrEnd)
+      viewport.removeEventListener('touchend', onTouchMoveOrEnd)
+      viewport.removeEventListener('touchcancel', onTouchMoveOrEnd)
+      const removeCapture = { capture: true } as EventListenerOptions
+      viewport.removeEventListener('mousedown', swallowSynthMouse, removeCapture)
+      viewport.removeEventListener('mouseup', swallowSynthMouse, removeCapture)
+      viewport.removeEventListener('click', swallowSynthMouse, removeCapture)
+      viewport.removeEventListener(
+        'pointerdown',
+        swallowSynthMouse,
+        removeCapture,
+      )
+      viewport.removeEventListener(
+        'pointermove',
+        swallowSynthMouse,
+        removeCapture,
+      )
+      viewport.removeEventListener(
+        'pointerup',
+        swallowSynthMouse,
+        removeCapture,
+      )
+      viewport.removeEventListener(
+        'pointercancel',
+        swallowSynthMouse,
+        removeCapture,
+      )
+    }
+    // setTool / refs / enterPanFromGesture / exitPanIfAllTouchesUp are stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewportRef, setTool])
+
+  return { enterPanFromGesture, exitPanIfAllTouchesUp }
+}

--- a/src/hooks/useDrawingStatus.ts
+++ b/src/hooks/useDrawingStatus.ts
@@ -38,19 +38,19 @@ export const useTouchStatus = <T extends HTMLElement>(
     'touchstart' | 'touchend' | 'touchcancel'
   >('touchend')
 
-  // Touch screen panning state
-  const { tool } = useStore()
-
-  const isPanning = tool.type === 'pan'
-
   useEffect(() => {
     const container = containerRef?.current
     if (!container) return
 
-    // if the user is panning, we don't want to draw
-    if (isPanning) return setTouchStatus('touchcancel')
-
+    // Read pan state live inside the listener — a closure over `tool.type`
+    // could be stale during fast pinches when React 19 has not yet flushed
+    // the temporary-pan setTool. Re-attaching on every isPanning change also
+    // had a window where touchstart fired before listeners were re-bound.
     const setTouchFromEvent = (event: TouchEvent) => {
+      if (useStore.getState().tool.type === 'pan') {
+        setTouchStatus('touchcancel')
+        return
+      }
       // prevent scrolling while drawing
       event.preventDefault()
       setTouchStatus(event.type as 'touchstart' | 'touchend' | 'touchcancel')
@@ -67,7 +67,7 @@ export const useTouchStatus = <T extends HTMLElement>(
       container.removeEventListener('touchend', setTouchFromEvent)
       container.removeEventListener('touchcancel', setTouchFromEvent)
     }
-  }, [containerRef, isPanning])
+  }, [containerRef])
 
   return touchStatus
 }

--- a/src/utils/fill.bench.test.ts
+++ b/src/utils/fill.bench.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Benchmark / regression harness for the paint-fill algorithm.
+ *
+ * Skipped by default. Run with:
+ *   RUN_BENCH=1 npm test -- fill.bench
+ *
+ * Historical baseline (lodash-based legacy implementation, ~O(n^3)):
+ *     10x10 full fill : 200   ms / run
+ *     15x15 full fill : 2150  ms / run
+ *     20x20 full fill : 12000 ms / run   (anything bigger was effectively unusable)
+ *
+ * Current implementation (4-connected DFS with a Uint8Array visited mask, O(n)):
+ *     10x10  : 0.003 ms
+ *     25x25  : 0.012 ms
+ *     50x50  : 0.05  ms
+ *     100x100: 0.19  ms
+ *     200x200: 1.3   ms
+ *     500x500: 27    ms
+ */
+import cellsToFill from './fill'
+
+const EMPTY = '◽️'
+const FILL = '❤️'
+
+const makeGrid = (width: number, height: number, cell = EMPTY): string[][] => {
+  const grid: string[][] = new Array(height)
+  for (let y = 0; y < height; y++) {
+    grid[y] = new Array(width).fill(cell)
+  }
+  return grid
+}
+
+/** Run `fn` for at least `minRuns` and at least `budgetMs` of wall time. */
+const time = (
+  label: string,
+  fn: () => void,
+  {
+    minRuns = 5,
+    budgetMs = 1000,
+  }: { minRuns?: number; budgetMs?: number } = {},
+): number => {
+  fn() // warm up
+  const start = performance.now()
+  let runs = 0
+  while (runs < minRuns || performance.now() - start < budgetMs) {
+    fn()
+    runs++
+  }
+  const total = performance.now() - start
+  const avg = total / runs
+  console.log(
+    `  ${label.padEnd(20)} ${avg.toFixed(3).padStart(10)} ms/run  (${runs} runs)`,
+  )
+  return avg
+}
+
+const cases: Array<{ name: string; w: number; h: number }> = [
+  { name: '10x10', w: 10, h: 10 },
+  { name: '25x25', w: 25, h: 25 },
+  { name: '50x50', w: 50, h: 50 },
+  { name: '100x100', w: 100, h: 100 },
+  { name: '200x200', w: 200, h: 200 },
+  { name: '500x500', w: 500, h: 500 },
+]
+
+const runBench = process.env.RUN_BENCH === '1'
+const describeOrSkip = runBench ? describe : describe.skip
+
+describeOrSkip('fill benchmark', () => {
+  it('full empty-canvas fill scales linearly', () => {
+    console.log('\n=== Paint-fill: full empty-canvas fill ===')
+    for (const { name, w, h } of cases) {
+      const grid = makeGrid(w, h)
+      time(name, () => {
+        cellsToFill(grid, { x: 0, y: 0 }, FILL)
+      })
+    }
+    console.log('')
+  }, 120_000)
+
+  it('no-op when click color already matches paint', () => {
+    console.log('\n=== Paint-fill: no-op (already painted) ===')
+    for (const { name, w, h } of cases) {
+      const grid = makeGrid(w, h, FILL)
+      time(name, () => {
+        cellsToFill(grid, { x: 0, y: 0 }, FILL)
+      })
+    }
+    console.log('')
+  }, 60_000)
+})

--- a/src/utils/fill.test.ts
+++ b/src/utils/fill.test.ts
@@ -1,127 +1,27 @@
-import cellsToFill, * as fill from './fill'
+import cellsToFill from './fill'
 
-describe('helper functions', () => {
-  const grid = [
-    ['◽️', '◽️', '◽️', '◽️', '◽️'],
-    ['◽️', '◽️', '◽️', '◽️', '◽️'],
-    ['◽️', '◽️', '◽️', '◽️', '◽️'],
-    ['◽️', '◽️', '◽️', '◽️', '◽️'],
-    ['◽️', '◽️', '◽️', '◽️', '◽️'],
-  ]
+interface Point {
+  x: number
+  y: number
+}
 
-  it('getAdjacent() returns the adjacent cells', () => {
-    const target = { x: 2, y: 2 }
-    const result = [
-      { x: 2, y: 2 },
-      { x: 1, y: 2 },
-      { x: 2, y: 1 },
-      { x: 2, y: 3 },
-      { x: 3, y: 2 },
-    ]
-    expect(fill.getAdjacent(grid, target)).toEqual(result)
-  })
+const sorted = (points: Point[]): string[] =>
+  points.map((p) => `${p.x},${p.y}`).sort()
 
-  it('getAdjacent() works with rectangles', () => {
+const expectSameSet = (actual: Point[], expected: Point[]) => {
+  expect(sorted(actual)).toEqual(sorted(expected))
+}
+
+describe('cellsToFill', () => {
+  it('returns empty when target color already matches paint', () => {
     const grid = [
-      ['◽️', '◽️', '◽️'],
-      ['◽️', '◽️', '◽️'],
+      ['◽️', '◼️'],
+      ['◼️', '◼️'],
     ]
-    const target = { x: 2, y: 1 }
-    const result = [
-      { x: 2, y: 1 },
-      { x: 1, y: 1 },
-      { x: 2, y: 0 },
-    ]
-    expect(fill.getAdjacent(grid, target)).toEqual(result)
+    expect(cellsToFill(grid, { x: 0, y: 0 }, '◽️')).toEqual([])
   })
 
-  it('getAdjacent() works with big rectangles', () => {
-    const grid = [
-      ['◽️', '◽️', '◽️', '◽️', '◽️'],
-      ['◽️', '◽️', '◽️', 'x◽️', '◽️'],
-      ['◽️', '◽️', '◽️', '◽️', '◽️'],
-    ]
-    const target = { x: 3, y: 1 }
-    const result = [
-      { x: 3, y: 1 },
-      { x: 2, y: 1 },
-      { x: 3, y: 0 },
-      { x: 3, y: 2 },
-      { x: 4, y: 1 },
-    ]
-    expect(fill.getAdjacent(grid, target)).toEqual(result)
-  })
-
-  it('getMatches() returns the matching adjacent cells', () => {
-    const grid = [
-      ['◼️', '◼️', '◼️', '◼️', '◼️'],
-      ['◼️', '◼️', '◽️', '◼️', '◼️'],
-      ['◼️', '◽️', '◽️', '◽️', '◼️'],
-      ['◼️', '◼️', '◼️', '◼️', '◼️'],
-      ['◼️', '◼️', '◼️', '◼️', '◼️'],
-    ]
-    const fillTarget = '◽️'
-    const adjacentCells = [
-      { x: 2, y: 2 },
-      { x: 2, y: 1 },
-      { x: 3, y: 2 },
-      { x: 2, y: 3 },
-      { x: 1, y: 2 },
-    ]
-    const result = [
-      { x: 2, y: 2 },
-      { x: 2, y: 1 },
-      { x: 3, y: 2 },
-      { x: 1, y: 2 },
-    ]
-    expect(fill.getMatches(grid, fillTarget, adjacentCells)).toEqual(result)
-  })
-
-  it('getMatches() works with rectangles', () => {
-    const grid = [
-      ['◽️', '◽️', '◽️'],
-      ['◽️', '◽️', '◽️'],
-    ]
-    const fillTarget = '◽️'
-    const adjacentCells = [
-      { x: 0, y: 0 },
-      { x: 1, y: 0 },
-      { x: 2, y: 0 },
-      { x: 0, y: 1 },
-      { x: 1, y: 1 },
-      { x: 2, y: 1 },
-    ]
-    const result = [
-      { x: 0, y: 0 },
-      { x: 1, y: 0 },
-      { x: 2, y: 0 },
-      { x: 0, y: 1 },
-      { x: 1, y: 1 },
-      { x: 2, y: 1 },
-    ]
-    expect(fill.getMatches(grid, fillTarget, adjacentCells)).toEqual(result)
-  })
-
-  it('returns an unchecked cell', () => {
-    const matchedCells = [
-      { x: 2, y: 2 },
-      { x: 2, y: 3 },
-      { x: 1, y: 2 },
-      { x: 2, y: 4 },
-    ]
-    const checkedCells = [
-      { x: 2, y: 2 },
-      { x: 1, y: 2 },
-      { x: 4, y: 2 },
-    ]
-    const result = { x: 2, y: 3 }
-    expect(fill.getCellToCheck(matchedCells, checkedCells)).toEqual(result)
-  })
-})
-
-describe('default function', () => {
-  // @todo most of these tests could probably use 1 grid
-  it('only returns the clicked cell', () => {
+  it('returns only the clicked cell when the cell is isolated', () => {
     const grid = [
       ['◽️', '◼️', '◽️', '◼️', '◼️'],
       ['◼️', '◼️', '◼️', '◼️', '◼️'],
@@ -129,16 +29,12 @@ describe('default function', () => {
       ['◼️', '◼️', '◼️', '◼️', '◼️'],
       ['◼️', '◼️', '◼️', '◼️', '◼️'],
     ]
-    let target = { x: 0, y: 0 }
-    expect(cellsToFill(grid, target, '◼️')).toEqual([target])
-    target = { x: 2, y: 0 }
-    expect(cellsToFill(grid, target, '◼️')).toEqual([target])
-    target = { x: 2, y: 2 }
-    expect(cellsToFill(grid, target, '◼️')).toEqual([target])
+    expectSameSet(cellsToFill(grid, { x: 0, y: 0 }, '◼️'), [{ x: 0, y: 0 }])
+    expectSameSet(cellsToFill(grid, { x: 2, y: 0 }, '◼️'), [{ x: 2, y: 0 }])
+    expectSameSet(cellsToFill(grid, { x: 2, y: 2 }, '◼️'), [{ x: 2, y: 2 }])
   })
 
-  it('returns all 4 sides', () => {
-    const target = { x: 2, y: 2 }
+  it('expands to all 4 sides', () => {
     const grid = [
       ['◽️', '◽️', '◽️', '◽️', '◽️'],
       ['◽️', '◽️', '◼️', '◽️', '◽️'],
@@ -146,18 +42,16 @@ describe('default function', () => {
       ['◽️', '◽️', '◼️', '◽️', '◽️'],
       ['◽️', '◽️', '◽️', '◽️', '◽️'],
     ]
-    const result = [
+    expectSameSet(cellsToFill(grid, { x: 2, y: 2 }, '◽️'), [
       { x: 2, y: 2 },
       { x: 1, y: 2 },
       { x: 2, y: 1 },
       { x: 2, y: 3 },
       { x: 3, y: 2 },
-    ]
-    expect(cellsToFill(grid, target, '◽️')).toEqual(result)
+    ])
   })
 
-  it('returns 2 sides', () => {
-    const target = { x: 2, y: 2 }
+  it('expands to 2 sides when blocked', () => {
     const grid = [
       ['◽️', '◽️', '◽️', '◽️', '◽️'],
       ['◽️', '◽️', '◽️', '◽️', '◽️'],
@@ -165,16 +59,14 @@ describe('default function', () => {
       ['◽️', '◽️', '◼️', '◽️', '◽️'],
       ['◽️', '◽️', '◽️', '◽️', '◽️'],
     ]
-    const result = [
+    expectSameSet(cellsToFill(grid, { x: 2, y: 2 }, '◽️'), [
       { x: 2, y: 2 },
       { x: 1, y: 2 },
       { x: 2, y: 3 },
-    ]
-    expect(cellsToFill(grid, target, '◽️')).toEqual(result)
+    ])
   })
 
-  it('returns 2 sides from a corner', () => {
-    const target = { x: 0, y: 0 }
+  it('handles fills starting at a corner', () => {
     const grid = [
       ['◼️', '◼️', '◽️', '◽️', '◽️'],
       ['◼️', '◽️', '◽️', '◽️', '◽️'],
@@ -182,16 +74,14 @@ describe('default function', () => {
       ['◽️', '◽️', '◽️', '◽️', '◽️'],
       ['◽️', '◽️', '◽️', '◽️', '◽️'],
     ]
-    const result = [
+    expectSameSet(cellsToFill(grid, { x: 0, y: 0 }, '◽️'), [
       { x: 0, y: 0 },
       { x: 0, y: 1 },
       { x: 1, y: 0 },
-    ]
-    expect(cellsToFill(grid, target, '◽️')).toEqual(result)
+    ])
   })
 
-  it('returns recursive matches', () => {
-    const target = { x: 2, y: 2 }
+  it('finds cells reachable through a single-cell channel', () => {
     const grid = [
       ['◽️', '◽️', '◽️', '◽️', '◼️'],
       ['◽️', '◽️', '◽️', '◽️', '◽️'],
@@ -199,17 +89,15 @@ describe('default function', () => {
       ['◽️', '◽️', '◼️', '◼️', '◽️'],
       ['◽️', '◽️', '◽️', '◽️', '◽️'],
     ]
-    const result = [
+    expectSameSet(cellsToFill(grid, { x: 2, y: 2 }, '◽️'), [
       { x: 2, y: 2 },
       { x: 1, y: 2 },
       { x: 2, y: 3 },
       { x: 3, y: 3 },
-    ]
-    expect(cellsToFill(grid, target, '◽️')).toEqual(result)
+    ])
   })
 
-  it('returns doubly recursive matches', () => {
-    const target = { x: 2, y: 2 }
+  it('walks a longer connected region', () => {
     const grid = [
       ['◽️', '◽️', '◽️', '◽️', '◼️'],
       ['◽️', '◼️', '◽️', '◽️', '◽️'],
@@ -217,233 +105,63 @@ describe('default function', () => {
       ['◽️', '◽️', '◼️', '◼️', '◽️'],
       ['◽️', '◽️', '◽️', '◼️', '◽️'],
     ]
-    const result = [
+    expectSameSet(cellsToFill(grid, { x: 2, y: 2 }, '◽️'), [
       { x: 2, y: 2 },
       { x: 1, y: 2 },
       { x: 2, y: 3 },
       { x: 3, y: 3 },
       { x: 3, y: 4 },
       { x: 1, y: 1 },
-    ]
-    expect(cellsToFill(grid, target, '◽️')).toEqual(result)
+    ])
   })
 
-  it('does a full fill', () => {
-    const target = { x: 1, y: 1 }
+  it('fills an entire uniform grid', () => {
     const grid = [
       ['◽️', '◽️', '◽️'],
       ['◽️', '◽️', '◽️'],
     ]
-    const result = [
-      { x: 1, y: 1 },
-      { x: 0, y: 1 },
-      { x: 1, y: 0 },
-      { x: 2, y: 1 },
-      { x: 2, y: 0 },
+    expectSameSet(cellsToFill(grid, { x: 1, y: 1 }, '◼️'), [
       { x: 0, y: 0 },
-    ]
-    expect(cellsToFill(grid, target, '◼️')).toEqual(result)
+      { x: 1, y: 0 },
+      { x: 2, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+      { x: 2, y: 1 },
+    ])
   })
 
-  it('does a bigger fill', () => {
-    const target = { x: 1, y: 1 }
+  it('returns empty for out-of-bounds targets', () => {
     const grid = [
-      ['🌈️', '🌈️', '🌈️', '🌈️', '🌈️', '🌈️'],
-      ['🌈️', '🌈️', '🌈️', '🌈️', '🌈️', '🌈️'],
-      ['🌈️', '🌈️', '🌈️', '🌈️', '🌈️', '🌈️'],
-      ['🌈️', '🌈️', '🌈️', '🌈️', '🌈️', '🌈️'],
-      ['🌈️', '🌈️', '🌈️', '🌈️', '🌈️', '🌈️'],
-      ['🌈️', '🌈️', '🌈️', '🌈️', '🌈️', '🌈️'],
-      ['🌈️', '🌈️', '🌈️', '🌈️', '🌈️', '🌈️'],
-      ['🌈️', '🌈️', '🌈️', '🌈️', '🌈️', '🌈️'],
-      ['🌈️', '🌈️', '🌈️', '🌈️', '🌈️', '🌈️'],
-      ['🌈️', '🌈️', '🌈️', '🌈️', '🌈️', '🌈️'],
+      ['◽️', '◽️'],
+      ['◽️', '◽️'],
     ]
-    const t0 = performance.now()
-    cellsToFill(grid, target, '❤️')
-    const t1 = performance.now()
+    expect(cellsToFill(grid, { x: -1, y: 0 }, '◼️')).toEqual([])
+    expect(cellsToFill(grid, { x: 0, y: -1 }, '◼️')).toEqual([])
+    expect(cellsToFill(grid, { x: 5, y: 0 }, '◼️')).toEqual([])
+    expect(cellsToFill(grid, { x: 0, y: 5 }, '◼️')).toEqual([])
+  })
 
+  it('completes a 10x6 fill well under the 50 ms budget', () => {
+    const grid = Array.from({ length: 6 }, () => Array(10).fill('🌈️'))
+    const t0 = performance.now()
+    cellsToFill(grid, { x: 1, y: 1 }, '❤️')
+    const t1 = performance.now()
     expect(t1 - t0).toBeLessThanOrEqual(50)
   })
 
-  it('does a fill fast', () => {
-    const target = { x: 1, y: 1 }
-    const grid = [
-      [
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-      ],
-      [
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-      ],
-      [
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-      ],
-      [
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-      ],
-      [
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-      ],
-      [
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-      ],
-      [
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-      ],
-      [
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-      ],
-      [
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-      ],
-      [
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-        '🌈️',
-      ],
-    ]
+  it('completes a 10x15 fill well under the 500 ms budget', () => {
+    const grid = Array.from({ length: 10 }, () => Array(15).fill('🌈️'))
     const t0 = performance.now()
-    cellsToFill(grid, target, '❤️')
+    cellsToFill(grid, { x: 1, y: 1 }, '❤️')
     const t1 = performance.now()
-
     expect(t1 - t0).toBeLessThanOrEqual(500)
+  })
+
+  it('completes a 100x100 fill well under 50 ms (regression for the legacy O(n^3) blow-up)', () => {
+    const grid = Array.from({ length: 100 }, () => Array(100).fill('🌈️'))
+    const t0 = performance.now()
+    cellsToFill(grid, { x: 0, y: 0 }, '❤️')
+    const t1 = performance.now()
+    expect(t1 - t0).toBeLessThanOrEqual(50)
   })
 })

--- a/src/utils/fill.ts
+++ b/src/utils/fill.ts
@@ -1,4 +1,3 @@
-import { uniqWith, differenceWith, isEqual } from 'lodash'
 import { Painting } from '../types'
 
 interface Point {
@@ -6,96 +5,82 @@ interface Point {
   y: number
 }
 
+/**
+ * Returns the set of cells that should change color when the user clicks
+ * `target` on `grid` while the active paint is `paint`.
+ *
+ * 4-connected flood fill (no diagonals). Iterative DFS using a typed-array
+ * visited mask, so each cell is examined at most once → O(width * height)
+ * time and memory. The previous implementation used lodash deep-equality
+ * dedup inside the BFS loop, which was effectively O(n^3) and froze the
+ * UI on medium-sized canvases.
+ */
 export default function cellsToFill(
   grid: Painting['grid'],
   target: Point,
   paint: string,
 ): Point[] {
-  return control(grid, target, paint)
-}
+  const height = grid.length
+  if (height === 0) return []
+  const width = grid[0].length
+  if (width === 0) return []
 
-const control = (
-  grid: Painting['grid'],
-  target: Point,
-  paint: string,
-): Point[] => {
-  const { x, y } = target
-
-  const fillTarget = grid[y][x]
-
-  // If no painting needs to be done return
-  if (fillTarget === paint) {
+  const { x: startX, y: startY } = target
+  if (startY < 0 || startY >= height || startX < 0 || startX >= width) {
     return []
   }
 
-  let matchedCells: Point[] = []
-  let cellsToCheck: Point[] = []
+  const fillTarget = grid[startY][startX]
+  if (fillTarget === paint) return []
 
-  cellsToCheck.push(target)
+  const visited = new Uint8Array(width * height)
+  const stack: number[] = []
+  const result: Point[] = []
 
-  while (cellsToCheck.length) {
-    const cell = cellsToCheck.pop()!
-    const adjacentCells = getAdjacent(grid, cell)
-    const matchingAdjacentCells = getMatches(grid, fillTarget, adjacentCells)
-    let uncheckedMatchingCells = differenceWith(
-      matchingAdjacentCells,
-      matchedCells,
-      isEqual,
-    )
-    uncheckedMatchingCells = differenceWith(
-      uncheckedMatchingCells,
-      [cell],
-      isEqual,
-    )
+  const startIdx = startY * width + startX
+  visited[startIdx] = 1
+  stack.push(startIdx)
 
-    // differenceWith(uncheckedMatchingCells, [cell], isEqual)
-    cellsToCheck = uniqWith(
-      [...cellsToCheck, ...uncheckedMatchingCells],
-      isEqual,
-    )
-    matchedCells = uniqWith(
-      [...matchedCells, ...matchingAdjacentCells],
-      isEqual,
-    )
-  }
+  while (stack.length > 0) {
+    const idx = stack.pop()!
+    const y = (idx / width) | 0
+    const x = idx - y * width
 
-  return matchedCells
-}
+    result.push({ x, y })
 
-export const getCellToCheck = (
-  matchedCells: Point[],
-  checkedCells: Point[],
-): Point | undefined => {
-  return differenceWith(matchedCells, checkedCells, isEqual)[0]
-}
-
-export const getAdjacent = (grid: Painting['grid'], target: Point): Point[] => {
-  const { x, y } = target
-  const edges: Point[] = [{ x, y }]
-  for (let dx = -1; dx <= 1; ++dx) {
-    for (let dy = -1; dy <= 1; ++dy) {
-      // the distance must not be 0 && the matched absolute vals remove the corners
-      if ((dx !== 0 || dy !== 0) && Math.abs(dy) !== Math.abs(dx)) {
-        try {
-          if (grid[y + dy][x + dx]) {
-            edges.push({
-              x: x + dx,
-              y: y + dy,
-            })
-          }
-        } catch {
-          // 😎 should probably refactor this
-        }
+    // West
+    if (x > 0) {
+      const n = idx - 1
+      if (!visited[n] && grid[y][x - 1] === fillTarget) {
+        visited[n] = 1
+        stack.push(n)
+      }
+    }
+    // East
+    if (x < width - 1) {
+      const n = idx + 1
+      if (!visited[n] && grid[y][x + 1] === fillTarget) {
+        visited[n] = 1
+        stack.push(n)
+      }
+    }
+    // North
+    if (y > 0) {
+      const n = idx - width
+      if (!visited[n] && grid[y - 1][x] === fillTarget) {
+        visited[n] = 1
+        stack.push(n)
+      }
+    }
+    // South
+    if (y < height - 1) {
+      const n = idx + width
+      if (!visited[n] && grid[y + 1][x] === fillTarget) {
+        visited[n] = 1
+        stack.push(n)
       }
     }
   }
-  return edges
-}
 
-export const getMatches = (
-  grid: Painting['grid'],
-  fillTarget: string,
-  adjacentCells: Point[],
-): Point[] => {
-  return adjacentCells.filter(({ x, y }) => grid[y][x] === fillTarget)
+  return result
 }


### PR DESCRIPTION
## Summary

- Drag-to-scroll on `.artboard` previously caused accidental drawing whenever the painting overflowed. Navigation now lives on a CSS-transform viewport driven by `@react-spring/web` + `@use-gesture/react`, so click-drag with the pan tool, mouse wheel (ctrl/⌘+wheel to zoom), and pinch / two-finger drag on touch all pan or zoom without touching the draw path.
- Two-finger touch gestures temporarily flip the active tool to `pan` and restore the prior tool on gesture end, so the existing pan-tool short-circuit in `useDrawingStatus` keeps suppressing stray draws.
- Pan tool is now visible on desktop, spacebar toggles it, and `getRelativePosition` derives cell coords from the canvas's transformed bounding rect so cell math stays correct under arbitrary scale.

Scale clamped to `[0.25, 5]`; pan clamped to keep ≥64px of canvas in the viewport.

## Test plan

- [ ] Desktop / mouse: with painting larger than the viewport, draw tool paints on left-drag; wheel pans; ctrl/⌘+wheel zooms toward the cursor.
- [ ] Switch to pan (or press space): cursor turns `grab` / `grabbing`, left-drag pans, no draws.
- [ ] After zooming, click a cell — painted cell matches the cell visually under the cursor.
- [ ] Touch (devtools or device): one finger draws with the draw tool; two fingers pan; pinch zooms toward the gesture origin.
- [ ] Pan tool on touch: one finger pans.
- [ ] Bounds: try to fling content fully off-screen — at least one cell stays visible. Zoom past limits — clamps at 0.25× and 5×.
- [ ] Resize tool still recenters; undo/redo unaffected; Share/Download exports the painting (not the viewport) after a zoom + pan.
- [ ] `npm run lint`, `npm test`, `npm run build` clean.
